### PR TITLE
quit() on webdriver to kill process; TimeOutException kills chromedriver

### DIFF
--- a/ptcaccount2/accounts.py
+++ b/ptcaccount2/accounts.py
@@ -163,11 +163,14 @@ def create_account(username, password, email, birthday):
     elem = driver.find_element_by_class_name("g-recaptcha")
     driver.execute_script("arguments[0].scrollIntoView(true);", elem)
 
-    # Waits 1 minute for you to input captcha
+    # Waits for you to input captcha
+    waitTimeInSec = 60
     try:
-        WebDriverWait(driver, 60).until(EC.text_to_be_present_in_element_value((By.ID, "g-recaptcha-response"), ""))
+        WebDriverWait(driver, waitTimeInSec).until(EC.text_to_be_present_in_element_value((By.ID, "g-recaptcha-response"), ""))
     except TimeoutException:
         driver.quit()
+        print("captcha was not entered within %s seconds." % waitTimeInSec)
+        return False
         
     print("Captcha successful. Sleeping for 1 second...")
     time.sleep(1)

--- a/ptcaccount2/accounts.py
+++ b/ptcaccount2/accounts.py
@@ -169,7 +169,7 @@ def create_account(username, password, email, birthday):
         WebDriverWait(driver, waitTimeInSec).until(EC.text_to_be_present_in_element_value((By.ID, "g-recaptcha-response"), ""))
     except TimeoutException:
         driver.quit()
-        print("captcha was not entered within %s seconds." % waitTimeInSec)
+        print("Captcha was not entered within %s seconds." % waitTimeInSec)
         return False
         
     print("Captcha successful. Sleeping for 1 second...")

--- a/ptcaccount2/accounts.py
+++ b/ptcaccount2/accounts.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import StaleElementReferenceException
+from selenium.common.exceptions import TimeoutException
 
 from ptcaccount2.ptcexceptions import *
 
@@ -163,7 +164,11 @@ def create_account(username, password, email, birthday):
     driver.execute_script("arguments[0].scrollIntoView(true);", elem)
 
     # Waits 1 minute for you to input captcha
-    WebDriverWait(driver, 60).until(EC.text_to_be_present_in_element_value((By.ID, "g-recaptcha-response"), ""))
+    try:
+        WebDriverWait(driver, 60).until(EC.text_to_be_present_in_element_value((By.ID, "g-recaptcha-response"), ""))
+    except TimeoutException:
+        driver.quit()
+        
     print("Captcha successful. Sleeping for 1 second...")
     time.sleep(1)
 
@@ -179,7 +184,7 @@ def create_account(username, password, email, birthday):
         raise
 
     print("Account successfully created.")
-    driver.close()
+    driver.quit()
     return True
 
 


### PR DESCRIPTION
It seems like the webdriver only closes the Chrome window if you call .close() on it, so it should be .quit(). And if the user does not enter the captcha within 60 seconds a timeout occurs, which now also quits the webdriver
