### PR TITLE
fixed missing parentheses

### DIFF
--- a/ptcaccount2/console.py
+++ b/ptcaccount2/console.py
@@ -80,7 +80,7 @@ def entry():
             if args.tofile:
                 with open("accounts.txt", 'a+') as writeto:
                     writeto.write('{}:{}'.format(account_info["username"], account_info["password"]) + "\n")
-                print "Appended to file accounts.txt"
+                print("Appended to file accounts.txt")
             account_summary.append({"username": account_info["username"], "password": account_info["password"]})
 
     # Handle account creation failure exceptions


### PR DESCRIPTION
Python 3 does not allow print without parentheses
