### PR TITLE
random_account does not return the tagged email

### DIFF
--- a/ptcaccount2/accounts.py
+++ b/ptcaccount2/accounts.py
@@ -250,6 +250,6 @@ def random_account(username=None, password=None, email=None, birthday=None, emai
     return {
         "username": try_username,
         "password": password,
-        "email": try_email
+        "email": use_email
     }
 


### PR DESCRIPTION
This makes `random_account` return with the email we actually used to create the account when `email_tag` is set to `True`, as opposed to the base email address.
